### PR TITLE
feat: flexible order time selection ui changes

### DIFF
--- a/packages/p2p/src/components/buy-sell/buy-sell-form.jsx
+++ b/packages/p2p/src/components/buy-sell/buy-sell-form.jsx
@@ -265,6 +265,18 @@ const BuySellForm = props => {
                                             ))}
                                     </div>
                                 </div>
+                                {/* TODO: Uncomment when BE is done */}
+                                {/* <div className='buy-sell__modal-field-wrapper'>
+                                    <div className='buy-sell__modal-field'>
+                                        <Text as='p' color='less-prominent' size='xxs'>
+                                                <Localize i18n_default_text="Order Completion time" />
+                                        </Text>
+                                        <Text as='p' color='general' size='xs'>
+                                            <Localize i18n_default_text='{{minutes}} minutes' values={{ minutes: 30 }} />
+                                        </Text>
+                                        
+                                    </div>
+                                </div> */}
                                 <div className='buy-sell__modal-line' />
                                 {buy_sell_store.is_sell_advert && payment_method_names && (
                                     <React.Fragment>

--- a/packages/p2p/src/components/modal-manager/modals/order-time-tooltip-modal/__tests__/order-time-tooltip-modal.spec.tsx
+++ b/packages/p2p/src/components/modal-manager/modals/order-time-tooltip-modal/__tests__/order-time-tooltip-modal.spec.tsx
@@ -14,6 +14,10 @@ jest.mock('Components/modal-manager/modal-manager-context', () => ({
     useModalManagerContext: jest.fn(() => mock_modal_manager),
 }));
 
+const props = {
+    order_time_info_message: 'Orders will expire if they aren’t completed within this time.',
+};
+
 const el_modal = document.createElement('div');
 
 describe('<OrderTimeTooltipModal />', () => {
@@ -27,12 +31,12 @@ describe('<OrderTimeTooltipModal />', () => {
     });
 
     it('should render OrderTimeTooltipModal', () => {
-        render(<OrderTimeTooltipModal />);
+        render(<OrderTimeTooltipModal {...props} />);
 
         expect(screen.getByText('Orders will expire if they aren’t completed within this time.')).toBeInTheDocument();
     });
     it('should handle ok button click', () => {
-        render(<OrderTimeTooltipModal />);
+        render(<OrderTimeTooltipModal {...props} />);
 
         const ok_button = screen.getByRole('button', { name: 'Ok' });
         userEvent.click(ok_button);

--- a/packages/p2p/src/components/modal-manager/modals/order-time-tooltip-modal/__tests__/order-time-tooltip-modal.spec.tsx
+++ b/packages/p2p/src/components/modal-manager/modals/order-time-tooltip-modal/__tests__/order-time-tooltip-modal.spec.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useModalManagerContext } from 'Components/modal-manager/modal-manager-context';
+import OrderTimeTooltipModal from '../order-time-tooltip-modal';
+
+const mock_modal_manager: Partial<ReturnType<typeof useModalManagerContext>> = {
+    hideModal: jest.fn(),
+    is_modal_open: true,
+};
+
+jest.mock('Components/modal-manager/modal-manager-context', () => ({
+    ...jest.requireActual('Components/modal-manager/modal-manager-context'),
+    useModalManagerContext: jest.fn(() => mock_modal_manager),
+}));
+
+const el_modal = document.createElement('div');
+
+describe('<OrderTimeTooltipModal />', () => {
+    beforeAll(() => {
+        el_modal.setAttribute('id', 'modal_root');
+        document.body.appendChild(el_modal);
+    });
+
+    afterAll(() => {
+        document.body.removeChild(el_modal);
+    });
+
+    it('should render OrderTimeTooltipModal', () => {
+        render(<OrderTimeTooltipModal />);
+
+        expect(screen.getByText('Orders will expire if they aren’t completed within this time.')).toBeInTheDocument();
+    });
+    it('should handle ok button click', () => {
+        render(<OrderTimeTooltipModal />);
+
+        const ok_button = screen.getByRole('button', { name: 'Ok' });
+        userEvent.click(ok_button);
+        expect(mock_modal_manager.hideModal).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/p2p/src/components/modal-manager/modals/order-time-tooltip-modal/index.ts
+++ b/packages/p2p/src/components/modal-manager/modals/order-time-tooltip-modal/index.ts
@@ -1,0 +1,3 @@
+import OrderTimeTooltipModal from './order-time-tooltip-modal';
+
+export default OrderTimeTooltipModal;

--- a/packages/p2p/src/components/modal-manager/modals/order-time-tooltip-modal/order-time-tooltip-modal.tsx
+++ b/packages/p2p/src/components/modal-manager/modals/order-time-tooltip-modal/order-time-tooltip-modal.tsx
@@ -3,7 +3,7 @@ import { Button, Modal, Text } from '@deriv/components';
 import { Localize } from 'Components/i18next';
 import { useModalManagerContext } from 'Components/modal-manager/modal-manager-context';
 
-const BlockUserModal = () => {
+const OrderTimeTooltipModal = () => {
     const { hideModal, is_modal_open } = useModalManagerContext();
 
     return (
@@ -22,4 +22,4 @@ const BlockUserModal = () => {
     );
 };
 
-export default BlockUserModal;
+export default OrderTimeTooltipModal;

--- a/packages/p2p/src/components/modal-manager/modals/order-time-tooltip-modal/order-time-tooltip-modal.tsx
+++ b/packages/p2p/src/components/modal-manager/modals/order-time-tooltip-modal/order-time-tooltip-modal.tsx
@@ -3,14 +3,18 @@ import { Button, Modal, Text } from '@deriv/components';
 import { Localize } from 'Components/i18next';
 import { useModalManagerContext } from 'Components/modal-manager/modal-manager-context';
 
-const OrderTimeTooltipModal = () => {
+type TOrderTimeTooltipModalProps = {
+    order_time_info_message: string;
+};
+
+const OrderTimeTooltipModal = ({ order_time_info_message }: TOrderTimeTooltipModalProps) => {
     const { hideModal, is_modal_open } = useModalManagerContext();
 
     return (
         <Modal has_close_icon={false} is_open={is_modal_open} small>
             <Modal.Body>
                 <Text color='prominent' size='xxs' line_height='xs'>
-                    <Localize i18n_default_text='Orders will expire if they aren’t completed within this time.' />
+                    <Localize i18n_default_text={order_time_info_message} />
                 </Text>
             </Modal.Body>
             <Modal.Footer>

--- a/packages/p2p/src/components/modal-manager/modals/order-time-tooltip-modal/order-time-tooltip-modal.tsx
+++ b/packages/p2p/src/components/modal-manager/modals/order-time-tooltip-modal/order-time-tooltip-modal.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Button, Modal, Text } from '@deriv/components';
+import { Localize } from 'Components/i18next';
+import { useModalManagerContext } from 'Components/modal-manager/modal-manager-context';
+
+const BlockUserModal = () => {
+    const { hideModal, is_modal_open } = useModalManagerContext();
+
+    return (
+        <Modal has_close_icon={false} is_open={is_modal_open} small>
+            <Modal.Body>
+                <Text color='prominent' size='xxs' line_height='xs'>
+                    <Localize i18n_default_text='Orders will expire if they aren’t completed within this time.' />
+                </Text>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button primary large onClick={hideModal}>
+                    <Localize i18n_default_text='Ok' />
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+};
+
+export default BlockUserModal;

--- a/packages/p2p/src/components/my-ads/create-ad-form.jsx
+++ b/packages/p2p/src/components/my-ads/create-ad-form.jsx
@@ -21,7 +21,9 @@ import { useStores } from 'Stores';
 import CreateAdSummary from './create-ad-summary.jsx';
 import CreateAdFormPaymentMethods from './create-ad-form-payment-methods.jsx';
 import { useModalManagerContext } from 'Components/modal-manager/modal-manager-context';
-import { api_error_codes } from '../../constants/api-error-codes.js';
+import { api_error_codes } from 'Constants/api-error-codes';
+import { time_list } from 'Constants/order-list';
+import OrderTimeSelection from './order-time-selection';
 
 const CreateAdFormWrapper = ({ children }) => {
     if (isMobile()) {
@@ -128,6 +130,7 @@ const CreateAdForm = () => {
                     max_transaction: '',
                     min_transaction: '',
                     offer_amount: '',
+                    order_completion_time: time_list[0].value,
                     payment_info: my_ads_store.payment_info,
                     rate_type: floating_rate_store.rate_type === ad_type.FLOAT ? '-0.01' : '',
                     type: buy_sell_store.create_sell_ad_from_no_ads ? buy_sell.SELL : buy_sell.BUY,
@@ -405,6 +408,9 @@ const CreateAdForm = () => {
                                                         required
                                                     />
                                                 )}
+                                            </Field>
+                                            <Field name='order_completion_time'>
+                                                {({ field }) => <OrderTimeSelection {...field} />}
                                             </Field>
                                             <div className='p2p-my-ads__form-payment-methods--text'>
                                                 <Text color='prominent'>

--- a/packages/p2p/src/components/my-ads/edit-ad-form.jsx
+++ b/packages/p2p/src/components/my-ads/edit-ad-form.jsx
@@ -150,6 +150,7 @@ const EditAdForm = () => {
                             max_transaction: max_order_amount_display,
                             min_transaction: min_order_amount_display,
                             offer_amount: amount_display,
+                            //TODO: Uncomment when order completion time is implemented
                             //order_completion_time: order_completion_time,
                             rate_type: setInitialAdRate(),
                             type,

--- a/packages/p2p/src/components/my-ads/edit-ad-form.jsx
+++ b/packages/p2p/src/components/my-ads/edit-ad-form.jsx
@@ -15,6 +15,7 @@ import { generateErrorDialogTitle, generateErrorDialogBody } from 'Utils/adverts
 import EditAdFormPaymentMethods from './edit-ad-form-payment-methods.jsx';
 import EditAdSummary from './edit-ad-summary.jsx';
 import { useModalManagerContext } from 'Components/modal-manager/modal-manager-context';
+import OrderTimeSelection from './order-time-selection';
 
 const EditAdFormWrapper = ({ children }) => {
     if (isMobile()) {
@@ -149,6 +150,7 @@ const EditAdForm = () => {
                             max_transaction: max_order_amount_display,
                             min_transaction: min_order_amount_display,
                             offer_amount: amount_display,
+                            //order_completion_time: order_completion_time,
                             rate_type: setInitialAdRate(),
                             type,
                             is_active:
@@ -426,6 +428,9 @@ const EditAdForm = () => {
                                                                 max_characters={300}
                                                             />
                                                         )}
+                                                    </Field>
+                                                    <Field name='order_completion_time'>
+                                                        {({ field }) => <OrderTimeSelection {...field} />}
                                                     </Field>
                                                     <div className='p2p-my-ads__form-payment-methods--text'>
                                                         <Text color='prominent'>

--- a/packages/p2p/src/components/my-ads/order-time-selection/__tests__/order-time-selection.spec.tsx
+++ b/packages/p2p/src/components/my-ads/order-time-selection/__tests__/order-time-selection.spec.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import * as formik from 'formik';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { isDesktop, isMobile } from '@deriv/shared';
+import { useModalManagerContext } from 'Components/modal-manager/modal-manager-context';
+import OrderTimeSelection from '../order-time-selection';
+
+const mockUseFormikContext = jest.spyOn(formik, 'useFormikContext') as jest.Mock;
+
+const mock_modal_manager: Partial<ReturnType<typeof useModalManagerContext>> = {
+    showModal: jest.fn(),
+};
+
+jest.mock('Components/modal-manager/modal-manager-context', () => ({
+    ...jest.requireActual('Components/modal-manager/modal-manager-context'),
+    useModalManagerContext: jest.fn(() => mock_modal_manager),
+}));
+
+jest.mock('@deriv/shared', () => ({
+    ...jest.requireActual('@deriv/shared'),
+    isMobile: jest.fn(() => false),
+    isDesktop: jest.fn(() => true),
+}));
+
+describe('<OrderTimeSelection/>', () => {
+    beforeEach(() => {
+        mockUseFormikContext.mockReturnValue({
+            handleSubmit: jest.fn(),
+            values: {},
+        });
+    });
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should render the OrderTimeSelection component', () => {
+        render(<OrderTimeSelection />);
+
+        expect(screen.getByText('Orders must be completed in')).toBeInTheDocument();
+        expect(screen.getByTestId('dt_order_time_selection_info_icon')).toBeInTheDocument();
+    });
+    it('should show tooltip message on hovering info icon in desktop view', () => {
+        render(<OrderTimeSelection />);
+        const info_icon = screen.getByTestId('dt_order_time_selection_info_icon');
+        userEvent.hover(info_icon);
+
+        expect(screen.getByText('Orders will expire if they aren’t completed within this time.')).toBeInTheDocument();
+    });
+    it('should open orderTimeTooltipModal on clicking info icon in responsive view', () => {
+        (isMobile as jest.Mock).mockReturnValue(true);
+        (isDesktop as jest.Mock).mockReturnValue(false);
+        render(<OrderTimeSelection />);
+
+        const info_icon = screen.getByTestId('dt_order_time_selection_info_icon');
+
+        userEvent.click(info_icon);
+        expect(mock_modal_manager.showModal).toHaveBeenCalledWith({ key: 'OrderTimeTooltipModal' });
+    });
+});

--- a/packages/p2p/src/components/my-ads/order-time-selection/__tests__/order-time-selection.spec.tsx
+++ b/packages/p2p/src/components/my-ads/order-time-selection/__tests__/order-time-selection.spec.tsx
@@ -55,6 +55,9 @@ describe('<OrderTimeSelection/>', () => {
         const info_icon = screen.getByTestId('dt_order_time_selection_info_icon');
 
         userEvent.click(info_icon);
-        expect(mock_modal_manager.showModal).toHaveBeenCalledWith({ key: 'OrderTimeTooltipModal' });
+        expect(mock_modal_manager.showModal).toHaveBeenCalledWith({
+            key: 'OrderTimeTooltipModal',
+            props: { order_time_info_message: 'Orders will expire if they aren’t completed within this time.' },
+        });
     });
 });

--- a/packages/p2p/src/components/my-ads/order-time-selection/index.ts
+++ b/packages/p2p/src/components/my-ads/order-time-selection/index.ts
@@ -1,0 +1,4 @@
+import OrderTimeSelection from './order-time-selection';
+import './order-time-selection.scss';
+
+export default OrderTimeSelection;

--- a/packages/p2p/src/components/my-ads/order-time-selection/order-time-selection.scss
+++ b/packages/p2p/src/components/my-ads/order-time-selection/order-time-selection.scss
@@ -1,0 +1,17 @@
+.order-time-selection {
+    max-width: 67.2rem;
+    margin-top: 2.4rem;
+    &__title {
+        display: flex;
+        align-items: center;
+        gap: 0.8rem;
+    }
+    .dc-dropdown__display {
+        height: 4rem;
+
+        .dc-text {
+            font-size: 1.2rem;
+            line-height: 1.8rem;
+        }
+    }
+}

--- a/packages/p2p/src/components/my-ads/order-time-selection/order-time-selection.tsx
+++ b/packages/p2p/src/components/my-ads/order-time-selection/order-time-selection.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Dropdown, Icon, Popover, Text } from '@deriv/components';
-import { Localize } from '@deriv/translations';
 import { FormikHandlers, FormikValues, useFormikContext } from 'formik';
+import { Dropdown, Icon, Popover, Text } from '@deriv/components';
 import { isMobile } from '@deriv/shared';
-import { order_time_info_message, time_list } from 'Constants/order-list';
+import { Localize } from '@deriv/translations';
 import { useModalManagerContext } from 'Components/modal-manager/modal-manager-context';
+import { order_time_info_message, time_list } from 'Constants/order-list';
 
 type TFormikContext = {
     handleChange: FormikHandlers['handleChange'];

--- a/packages/p2p/src/components/my-ads/order-time-selection/order-time-selection.tsx
+++ b/packages/p2p/src/components/my-ads/order-time-selection/order-time-selection.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { FormikHandlers, FormikValues, useFormikContext } from 'formik';
 import { Dropdown, Icon, Popover, Text } from '@deriv/components';
 import { isMobile } from '@deriv/shared';
-import { Localize } from '@deriv/translations';
+import { Localize } from 'Components/i18next';
 import { useModalManagerContext } from 'Components/modal-manager/modal-manager-context';
 import { order_time_info_message, time_list } from 'Constants/order-list';
 

--- a/packages/p2p/src/components/my-ads/order-time-selection/order-time-selection.tsx
+++ b/packages/p2p/src/components/my-ads/order-time-selection/order-time-selection.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Dropdown, Icon, Popover, Text } from '@deriv/components';
+import { Localize } from '@deriv/translations';
+import { FormikHandlers, FormikValues, useFormikContext } from 'formik';
+import { isMobile } from '@deriv/shared';
+import { order_time_info_message, time_list } from 'Constants/order-list';
+import { useModalManagerContext } from 'Components/modal-manager/modal-manager-context';
+
+type TFormikContext = {
+    handleChange: FormikHandlers['handleChange'];
+    values: FormikValues;
+};
+
+const OrderTimeSelection = ({ ...field }: FormikValues) => {
+    const { values, handleChange }: TFormikContext = useFormikContext<TFormikContext>();
+    const { showModal } = useModalManagerContext();
+    return (
+        <div className='order-time-selection'>
+            <div className='order-time-selection__title'>
+                <Text color='prominent' size='xs' line_height='xl'>
+                    <Localize i18n_default_text='Orders must be completed in' />
+                </Text>
+                <Popover alignment='top' message={order_time_info_message}>
+                    <Icon
+                        data_testid='dt_order_time_selection_info_icon'
+                        icon='IcInfoOutline'
+                        onClick={() => isMobile() && showModal({ key: 'OrderTimeTooltipModal' })}
+                    />
+                </Popover>
+            </div>
+            <Dropdown
+                {...field}
+                className='order-time-selection__time-dropdown'
+                is_align_text_left
+                list={time_list}
+                onChange={handleChange}
+                value={values.order_completion_time}
+            />
+        </div>
+    );
+};
+
+export default OrderTimeSelection;

--- a/packages/p2p/src/components/my-ads/order-time-selection/order-time-selection.tsx
+++ b/packages/p2p/src/components/my-ads/order-time-selection/order-time-selection.tsx
@@ -2,14 +2,16 @@ import React from 'react';
 import { FormikHandlers, FormikValues, useFormikContext } from 'formik';
 import { Dropdown, Icon, Popover, Text } from '@deriv/components';
 import { isMobile } from '@deriv/shared';
-import { Localize } from 'Components/i18next';
+import { localize, Localize } from 'Components/i18next';
 import { useModalManagerContext } from 'Components/modal-manager/modal-manager-context';
-import { order_time_info_message, time_list } from 'Constants/order-list';
+import { time_list } from 'Constants/order-list';
 
 type TFormikContext = {
     handleChange: FormikHandlers['handleChange'];
     values: FormikValues;
 };
+
+const order_time_info_message = localize('Orders will expire if they aren’t completed within this time.');
 
 const OrderTimeSelection = ({ ...field }: FormikValues) => {
     const { values, handleChange }: TFormikContext = useFormikContext<TFormikContext>();
@@ -24,7 +26,10 @@ const OrderTimeSelection = ({ ...field }: FormikValues) => {
                     <Icon
                         data_testid='dt_order_time_selection_info_icon'
                         icon='IcInfoOutline'
-                        onClick={() => isMobile() && showModal({ key: 'OrderTimeTooltipModal' })}
+                        onClick={() =>
+                            isMobile() &&
+                            showModal({ key: 'OrderTimeTooltipModal', props: { order_time_info_message } })
+                        }
                     />
                 </Popover>
             </div>

--- a/packages/p2p/src/constants/modals.js
+++ b/packages/p2p/src/constants/modals.js
@@ -118,6 +118,11 @@ export const modals = {
             /* webpackChunkName: "order-details-confirm-modal" */ 'Components/modal-manager/modals/order-details-confirm-modal'
         )
     ),
+    OrderTimeTooltipModal: React.lazy(() =>
+        import(
+            /* webpackChunkName: "order-time-tooltip-modal" */ 'Components/modal-manager/modals/order-time-tooltip-modal'
+        )
+    ),
     QuickAddModal: React.lazy(() =>
         import(/* webpackChunkName: "quick-add-modal" */ 'Components/modal-manager/modals/quick-add-modal')
     ),

--- a/packages/p2p/src/constants/order-list.js
+++ b/packages/p2p/src/constants/order-list.js
@@ -5,8 +5,6 @@ export const order_list = {
     INACTIVE: 'inactive',
 };
 
-export const order_time_info_message = localize('Orders will expire if they aren’t completed within this time.');
-
 //TODO: to be finalized.
 export const time_list = [
     {

--- a/packages/p2p/src/constants/order-list.js
+++ b/packages/p2p/src/constants/order-list.js
@@ -1,4 +1,36 @@
+import { localize } from 'Components/i18next';
+
 export const order_list = {
     ACTIVE: 'active',
     INACTIVE: 'inactive',
 };
+
+export const order_time_info_message = localize('Orders will expire if they aren’t completed within this time.');
+
+//TODO: to be finalized.
+export const time_list = [
+    {
+        text: localize('1 hour'),
+        value: '60',
+    },
+    {
+        text: localize('1.5 hours'),
+        value: '90',
+    },
+    {
+        text: localize('2 hours'),
+        value: '120',
+    },
+    {
+        text: localize('45 minutes'),
+        value: '45',
+    },
+    {
+        text: localize('30 minutes'),
+        value: '30',
+    },
+    {
+        text: localize('15 minutes'),
+        value: '15',
+    },
+];

--- a/packages/p2p/src/stores/my-ads-store.js
+++ b/packages/p2p/src/stores/my-ads-store.js
@@ -201,6 +201,7 @@ export default class MyAdsStore extends BaseStore {
             amount: Number(values.offer_amount),
             max_order_amount: Number(values.max_transaction),
             min_order_amount: Number(values.min_transaction),
+            order_completion_time: values.order_completion_time,
             rate_type: this.root_store.floating_rate_store.rate_type,
             rate: Number(values.rate_type),
             ...(this.payment_method_names.length > 0 && !is_sell_ad
@@ -360,6 +361,7 @@ export default class MyAdsStore extends BaseStore {
             id: this.selected_ad_id,
             max_order_amount: Number(values.max_transaction),
             min_order_amount: Number(values.min_transaction),
+            order_completion_time: values.order_completion_time,
             rate_type: this.required_ad_type,
             rate: Number(values.rate_type),
             ...(this.payment_method_names.length > 0 && !is_sell_ad


### PR DESCRIPTION


## Changes:

ui changes for flexible order time selection => dropdown in create/edit ad, new modal onclicking info icon

### Screenshots:

Please provide some screenshots of the change.
![Screenshot 2023-08-24 at 9 50 38 AM](https://github.com/nada-deriv/deriv-app/assets/122768621/85da1615-8f54-4a67-b5e5-6bea4826e804)
![Screenshot 2023-08-24 at 9 51 04 AM](https://github.com/nada-deriv/deriv-app/assets/122768621/902fa3e6-cb4f-4f96-b5af-943f6eb95c72)

![Screenshot 2023-08-24 at 10 02 41 AM](https://github.com/nada-deriv/deriv-app/assets/122768621/e0bb4c4f-3de5-4223-aec5-eddaea95030d)
